### PR TITLE
Remove code that auto runs Repair and Rebuild

### DIFF
--- a/packages/CanvasIFrameModule/manifest.php
+++ b/packages/CanvasIFrameModule/manifest.php
@@ -48,10 +48,4 @@ $installdefs = array(
         'language' => 'en_us',
       ),
   ),
-   'post_execute' => array(
-       '<basepath>/scripts/cleanup.php',
-   ),
-   'post_uninstall' => array(
-       '<basepath>/scripts/cleanup.php',
-   ),
 );

--- a/packages/CanvasIFrameModule/readme.MD
+++ b/packages/CanvasIFrameModule/readme.MD
@@ -2,3 +2,5 @@
 
 This module creates a new module named Test that displays an iframe.  This module also creates a button that links to 
 the new Test module.  The button can be found toward the top of the Opportunities module.
+
+Note:  you MUST run Quick Repair and Rebuild after install in order for the button to work.

--- a/packages/CanvasIFrameModule/scripts/cleanup.php
+++ b/packages/CanvasIFrameModule/scripts/cleanup.php
@@ -1,9 +1,0 @@
-<?php
-/**
- * Copyright 2017 SugarCRM Inc.  Licensed by SugarCRM under the Apache 2.0 license.
- */
-if (! defined('sugarEntry') || ! sugarEntry) die('Not A Valid Entry Point');
-require_once("modules/Administration/QuickRepairAndRebuild.php");
-$randc = new RepairAndClear();
-//Rebuild extensions then clear include/javascript files
-$randc->repairAndClearAll(array('clearAll'), array(translate('LBL_ALL_MODULES')), true, false, '');


### PR DESCRIPTION
The code that auto runs Repair and Rebuild does not work. See https://sugarcrm.atlassian.net/browse/DE-387 for more info. Instead,
we'll tell users they need to run Quick Repair manually.