### PR TITLE
Recent changes api

### DIFF
--- a/packages/RecentChangesAPI/pack.php
+++ b/packages/RecentChangesAPI/pack.php
@@ -59,10 +59,7 @@ $manifest = array(
 
 $installdefs = array(
     'beans' => array (),
-    'id' => $packageID,
-    'post_execute' => array(
-        'scripts/cleanup.php',
-    ),
+    'id' => $packageID
 );
 
 echo "Creating {$zipFile} ... \n";

--- a/packages/RecentChangesAPI/pack.php
+++ b/packages/RecentChangesAPI/pack.php
@@ -1,0 +1,96 @@
+#!/usr/bin/env php
+<?php
+// Copyright 2018 SugarCRM Inc.  Licensed by SugarCRM under the Apache 2.0 license.
+
+
+$packageID = "BuildingBlock_RecentChangesAPI";
+$packageLabel = "RecentChangesAPI";
+$supportedVersionRegex = '(8\..*|7\.(9|10|11)\..*)';
+$acceptableSugarFlavors = array('PRO','ENT','ULT');
+$description = 'Adds a REST API endpoint that makes it easy to identify Users who have had recent changes to their assigned records.';
+/******************************/
+
+if (empty($argv[1])) {
+    if (file_exists("version")) {
+        $version = file_get_contents("version");
+    }
+} else {
+    $version = $argv[1];
+}
+
+if (empty($version)){
+    die("Use $argv[0] [version]\n");
+}
+
+$id = "{$packageID}-{$version}";
+
+$directory = "releases";
+if(!is_dir($directory)){
+    mkdir($directory);
+}
+
+$zipFile = $directory . "/sugarcrm-{$id}.zip";
+
+
+if (file_exists($zipFile)) {
+    die("Error:  Release $zipFile already exists, so a new zip was not created. To generate a new zip, either delete the"
+        . " existing zip file or update the version number in the version file AND then run the script to build the"
+        . " module again. \n");
+}
+
+$manifest = array(
+    'id' => $packageID,
+    'name' => $packageLabel,
+    'description' => $description,
+    'version' => $version,
+    'author' => 'SugarCRM, Inc.',
+    'is_uninstallable' => 'true',
+    'published_date' => date("Y-m-d H:i:s"),
+    'type' => 'module',
+    'acceptable_sugar_versions' => array(
+        'exact_matches' => array(
+        ),
+        'regex_matches' => array(
+            $supportedVersionRegex,
+        ),
+    ),
+    'acceptable_sugar_flavors' => $acceptableSugarFlavors,
+);
+
+$installdefs = array(
+    'beans' => array (),
+    'id' => $packageID,
+    'post_execute' => array(
+        'scripts/cleanup.php',
+    ),
+);
+
+echo "Creating {$zipFile} ... \n";
+$zip = new ZipArchive();
+$zip->open($zipFile, ZipArchive::CREATE);
+$basePath = realpath('src/');
+$files = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($basePath, RecursiveDirectoryIterator::SKIP_DOTS),
+    RecursiveIteratorIterator::LEAVES_ONLY
+);
+foreach ($files as $name => $file) {
+    if ($file->isFile()) {
+        $fileReal = $file->getRealPath();
+        $fileRelative = 'src' . str_replace($basePath, '', $fileReal);
+        echo " [*] $fileRelative \n";
+        $zip->addFile($fileReal, $fileRelative);
+        $installdefs['copy'][] = array(
+            'from' => '<basepath>/' . $fileRelative,
+            'to' => preg_replace('/^src\/(.*)/', '$1', $fileRelative),
+        );
+    }
+}
+$manifestContent = sprintf(
+    "<?php\n\$manifest = %s;\n\$installdefs = %s;\n",
+    var_export($manifest, true),
+    var_export($installdefs, true)
+);
+$zip->addFromString('manifest.php', $manifestContent);
+$zip->close();
+echo "Done creating {$zipFile}\n\n";
+exit(0);

--- a/packages/RecentChangesAPI/src/custom/modules/Users/clients/base/api/CustomRecentChangesApi.php
+++ b/packages/RecentChangesAPI/src/custom/modules/Users/clients/base/api/CustomRecentChangesApi.php
@@ -1,0 +1,55 @@
+<?php
+// Copyright 2018 SugarCRM Inc.  Licensed by SugarCRM under the Apache 2.0 license.
+
+/**
+ * Class CustomRecentChangesApi
+ */
+class CustomRecentChangesApi extends SugarApi
+{
+    public function registerApiRest()
+    {
+        return array(
+            'recentChanges' => array(
+                'reqType' => 'GET',
+                'path' => array('Users', 'recentChanges'),
+                'method' => 'getRecentChanges',
+                'shortHelp' => 'Identify Users who have had recent changes to their assigned records.',
+                'longHelp' => 'custom/modules/Users/clients/base/api/help/CustomRecentChangesApi.html',
+            ),
+        );
+    }
+
+    /**
+     * @param ServiceBase $api
+     * @param array $args
+     * @return array List of User ID strings
+     */
+    public function getRecentChanges(ServiceBase $api, array $args)
+    {
+        // allow only admins
+        // all fields required
+        // use input validation framework
+        $query = new SugarQuery();
+        $query->distinct(true);
+        $query->select('assigned_user_id');
+        $query->from(BeanFactory::newBean('Meetings'), array('add_deleted'=>true));
+        $query->where()->gt('date_modified','2018-02-14T12:00:00Z');
+        $result = $query->execute();
+        return $this->convertToResponseArray($result);
+    }
+
+    /**
+     * Pulls out the assigned user ID in each row of the response and appends it to a simple string array.
+     * This will simplify the JSON response that is sent back.
+     * @param $data
+     * @return array
+     */
+    protected function convertToResponseArray($data)
+    {
+        $result = array();
+        foreach($data as $obj){
+            $result[] = $obj['assigned_user_id'];
+        }
+        return $result;
+    }
+}

--- a/packages/RecentChangesAPI/src/custom/modules/Users/clients/base/api/CustomRecentChangesApi.php
+++ b/packages/RecentChangesAPI/src/custom/modules/Users/clients/base/api/CustomRecentChangesApi.php
@@ -178,7 +178,7 @@ class CustomRecentChangesApi extends SugarApi
      *          {
      *              "id": "sample user id",
      *              "name": "the user_name associated with the above user id",
-     *              "_module": "the module where the record changed"
+     *              "_recentlyChanged": "array of modules where the user has changes"
      *          }
      *      ]
      * }
@@ -189,23 +189,35 @@ class CustomRecentChangesApi extends SugarApi
      */
     protected function convertToResponseArray($currentTime, $dataArray)
     {
-        $users = array();
-
-        foreach($dataArray as $module => $data){
-            foreach($data as $obj){
-                $users[] = array(
-                    'id' => $obj['id'],
-                    'name' => $obj['user_name'],
-                    '_module' => $module
-                );
+        // Loop through each record in the $dataArray, creating a record in $recordResults for each user
+        $recordResults = array();
+        foreach($dataArray as $module => $users){
+            foreach($users as $user){
+                // If a record for the user already exists in $recordResults, simply add the module to the _recentlyChanged array
+                if($recordResults[$user['id']]){
+                    $recordResults[$user['id']]['_recentlyChanged'][] = $module;
+                } // Else create a new record in $recordResults
+                else {
+                    $recordResults[$user['id']] = array(
+                        'id' => $user['id'],
+                        'name' => $user['user_name'],
+                        '_recentlyChanged' => array($module)
+                    );
+                }
             }
         }
 
-        $result = array(
-            'currentTime' => $currentTime,
-            'records' => $users
-        );
+        // $recordResults uses the user's id as the key for each record in the array. Create a new $prettyRecordResults
+        // array that does not have keys for each record in the array
+        $prettyRecordResults = array();
+        forEach($recordResults as $record){
+            $prettyRecordResults[] = $record;
+        }
 
-        return $result;
+        // Return the current time and the array of records
+        return array(
+            'currentTime' => $currentTime,
+            'records' => $prettyRecordResults
+        );
     }
 }

--- a/packages/RecentChangesAPI/src/custom/modules/Users/clients/base/api/CustomRecentChangesApi.php
+++ b/packages/RecentChangesAPI/src/custom/modules/Users/clients/base/api/CustomRecentChangesApi.php
@@ -1,11 +1,36 @@
 <?php
 // Copyright 2018 SugarCRM Inc.  Licensed by SugarCRM under the Apache 2.0 license.
 
+use Symfony\Component\Validator\Constraints as Assert;
+use Sugarcrm\Sugarcrm\Security\Validator\Validator;
+use Sugarcrm\Sugarcrm\Security\Validator\Constraints\Mvc;
+
 /**
  * Class CustomRecentChangesApi
  */
 class CustomRecentChangesApi extends SugarApi
 {
+    /**
+     * The format for date strings
+     */
+    private $dateFormat;
+
+    /**
+     * The validator we will use to validate user input
+     */
+    private $validator;
+
+    function __construct()
+    {
+        $this->dateFormat = 'Y-m-d G:i:s T';
+        $this->validator = Validator::getService();
+    }
+
+    /**
+     * Registers a custom API endpoint at /Users/recentChanges.
+     * The endpoint identifies users who have had recent changes to their assigned records.
+     * @return array The definition of the custom endpoint
+     */
     public function registerApiRest()
     {
         return array(
@@ -13,43 +38,177 @@ class CustomRecentChangesApi extends SugarApi
                 'reqType' => 'GET',
                 'path' => array('Users', 'recentChanges'),
                 'method' => 'getRecentChanges',
-                'shortHelp' => 'Identify Users who have had recent changes to their assigned records.',
+                'shortHelp' => 'Identify Users who have had recent changes to their assigned Meeting records.',
                 'longHelp' => 'custom/modules/Users/clients/base/api/help/CustomRecentChangesApi.html',
             ),
         );
     }
 
     /**
+     * This is the function that is used for /Users/recentChanges endpoint
      * @param ServiceBase $api
-     * @param array $args
-     * @return array List of User ID strings
+     * @param array $args The arguments passed to the GET request. All params are required:
+     *      since: the datetime from which you want to get changes
+     *      modules: a comma separated list of modules that will be checked
+     *      add_deleted: Whether or not "'deleted' = 0" should be added to Where clause of generated SQL query. Value should be 0 or 1
+     * @return array JSON array containing the server's current time and a list of users with changes
+     * @throws SugarApiExceptionNotAuthorized if the user is not an admin
      */
     public function getRecentChanges(ServiceBase $api, array $args)
     {
-        // allow only admins
-        // all fields required
-        // use input validation framework
-        $query = new SugarQuery();
-        $query->distinct(true);
-        $query->select('assigned_user_id');
-        $query->from(BeanFactory::newBean('Meetings'), array('add_deleted'=>true));
-        $query->where()->gt('date_modified','2018-02-14T12:00:00Z');
-        $result = $query->execute();
-        return $this->convertToResponseArray($result);
+        // Ensure the current user is an admin
+        global $current_user;
+        if (!$current_user->is_admin) {
+            throw new SugarApiExceptionNotAuthorized('You do not have admin permissions');
+        }
+
+        // Validate the params
+        $sinceParam = $this->validateSinceParam($args['since']);
+        $AddDeletedParam = $this->validateAddDeletedParam($args['add_deleted']);
+        $modulesParam = $this->validateModulesParam($args['modules']);
+
+        // Get the server's current time
+        // TODO:  Is this the right way to get the current server timestamp?
+        global $timedate;
+        $currentTime = $timedate->getNow()->format($this->dateFormat);
+
+        // Query for updated records
+        $arrayOfQueryResults = $this->queryForRecentChanges($sinceParam, $currentTime, $modulesParam, $AddDeletedParam);
+
+        // Return the formatted results
+        return $this->convertToResponseArray($currentTime, $arrayOfQueryResults);
     }
 
     /**
-     * Pulls out the assigned user ID in each row of the response and appends it to a simple string array.
-     * This will simplify the JSON response that is sent back.
-     * @param $data
-     * @return array
+     * Query for the list of user_ids and associated user_names for users who have records updated between $dateTimeOne
+     * and $dateTimeTwo
+     * @param $dateTimeOne Search for records updated after this dateTime
+     * @param $dateTimeTwo Search for records updated up to and including this dateTime
+     * @param $modules List of modules to query for updates
+     * @param $addDeleted Whether or not 'deleted' = 0 should be added to Where clause of generated SQL query
+     * @return array Array of query results. Each module in $modules will have its own set of results in the array.
      */
-    protected function convertToResponseArray($data)
+    protected function queryForRecentChanges($dateTimeOne, $dateTimeTwo, $modules, $addDeleted)
     {
-        $result = array();
-        foreach($data as $obj){
-            $result[] = $obj['assigned_user_id'];
+        $arrayOfQueryResults = array();
+
+        foreach ($modules as $module) {
+            $query = new SugarQuery();
+            $query->distinct(true);
+            $query->from(BeanFactory::newBean($module), array('team_security' => true, 'add_deleted' => $addDeleted));
+            //TODO:  I was getting invalid link errors for modules like Accounts and Opportunities when I tried to do a
+            // join instead of a joinTable.  Is there a better way to get the table name than lower casing the module name?
+            $tableName = strtolower($module);
+            $query->joinTable('users')->on()
+                ->equalsField("$tableName.assigned_user_id", 'users.id');
+            $query->select(array('users.id', 'users.user_name'));
+            $query->where()->gt('date_modified', $dateTimeOne);
+            $query->where()->lte('date_modified', $dateTimeTwo);
+            $result = $query->execute();
+            $arrayOfQueryResults[] = $result;
         }
+        return $arrayOfQueryResults;
+    }
+
+    /**
+     * Ensures the since param has been passed and that it uses the correct date format
+     * @param $sinceParam The param passed in as an argument
+     * @return mixed The validated param
+     * @throws SugarApiExceptionInvalidParameter if the since param is not in the correct date format
+     * @throws SugarApiExceptionMissingParameter if the since param is not passed
+     */
+    protected function validateSinceParam($sinceParam){
+        if (empty($sinceParam)) {
+            throw new SugarApiExceptionMissingParameter('Missing required parameter: since');
+        }
+
+        $errors = $this->validator->validate($sinceParam, new Assert\DateTime(array('format' => $this->dateFormat)));
+        if (count($errors) > 0) {
+            throw new SugarApiExceptionInvalidParameter((string)$errors . '    since param should be of the format '
+                . $this->dateFormat . '.');
+        }
+        return $sinceParam;
+    }
+
+    /**
+     * Ensures the add_deleted param has been passed and that it is a boolean
+     * @param $AddDeletedParam The param passed in as an argument
+     * @return mixed The validated param
+     * @throws SugarApiExceptionInvalidParameter if the param is not a boolean
+     * @throws SugarApiExceptionMissingParameter if the param is not passed
+     */
+    protected function validateAddDeletedParam($AddDeletedParam){
+        if (empty($AddDeletedParam) && $AddDeletedParam != '0') {
+            throw new SugarApiExceptionMissingParameter('Missing required parameter: add_deleted');
+        }
+
+        $isTrueErrors = $this->validator->validate($AddDeletedParam, new Assert\IsTrue());
+        $isFalseErrors = $this->validator->validate($AddDeletedParam, new Assert\IsFalse());
+        if (count($isTrueErrors) > 0 && count($isFalseErrors) > 0) {
+            throw new SugarApiExceptionInvalidParameter('The value of add_deleted should be set to 0 or 1');
+        }
+        return $AddDeletedParam;
+    }
+
+    /**
+     * Ensure the modules param has been passed and that it is a comma separated list of valid modules
+     * @param $modulesParam A comma separated list of modules
+     * @return array A list of modules
+     * @throws SugarApiExceptionInvalidParameter if any of the modules in the list are not valid
+     * @throws SugarApiExceptionMissingParameter if the param is not passed
+     */
+    protected function validateModulesParam($modulesParam){
+        if (empty($modulesParam)) {
+            throw new SugarApiExceptionMissingParameter('Missing required parameter: modules');
+        }
+
+        $modules = explode(',', $modulesParam);
+        foreach ($modules as $module) {
+            $errors = $this->validator->validate($module, new Mvc\ModuleName());
+            if (count($errors) > 0) {
+                throw new SugarApiExceptionInvalidParameter('Error validating module: ' . (string)$errors);
+            }
+        }
+        return $modules;
+    }
+
+    /**
+     * Converts the query response data to a JSON array
+     *
+     * The response will be in the following format:
+     * {
+     *      "currentTime": "Y-m-d G:i:s T",
+     *      "usersWithRecentChanges": [
+     *          {
+     *              "assigned_user_id": "sample user id",
+     *              "user_name": "the user_name assocated with the above user id"
+     *          }
+     *      ]
+     * }
+     *
+     * @param $currentTime The current datetime that was used as part of the query
+     * @param $data Array of data results returned from queries
+     * @return array The query response data formatted as a JSON array
+     */
+    protected function convertToResponseArray($currentTime, $dataArray)
+    {
+        $users = array();
+
+        //TODO:  Do you want to know which module the update is in as well?
+        foreach($dataArray as $data){
+            foreach($data as $obj){
+                $users[] = array(
+                    'assigned_user_id' => $obj['id'],
+                    'user_name' => $obj['user_name']
+                );
+            }
+        }
+
+        $result = array(
+            'currentTime' => $currentTime,
+            'usersWithRecentChanges' => $users
+        );
+
         return $result;
     }
 }

--- a/packages/RecentChangesAPI/src/custom/modules/Users/clients/base/api/help/CustomRecentChangesApi.html
+++ b/packages/RecentChangesAPI/src/custom/modules/Users/clients/base/api/help/CustomRecentChangesApi.html
@@ -26,7 +26,7 @@
             since
         </td>
         <td>
-            Timestamp (String) of the format <strong>Y-m-d G:i:s T</strong>.
+            Timestamp (String) in the format of <strong>Y-m-d\TH:i:sP</strong> (ATOM/RFC3339).
         </td>
         <td>
             Selects users with records modified since this time.
@@ -66,17 +66,23 @@
     </tbody>
 </table>
 
-<h3>Request</h3>
+<h3>POST Request</h3>
 <pre class="pre-scrollable">
-http://{site_url}/rest/vXX/Users/recentChanges
+POST http://{site_url}/rest/vXX/Users/recentChanges
 
 {
-	"since":"2018-03-01 19:11:30 UTC",
+	"since":"2018-02-17T22:00:00+00:00",
 	"modules":"Meetings,Contacts",
 	"include_deleted":"1"
 }
+
 </pre>
 
+<h3>GET Request</h3>
+<pre class="pre-scrollable">
+GET http://{site_url}/rest/vXX/Users/recentChanges?since=2018-02-17T22%3A00%3A00%2B00%3A00&amp;modules=Meetings,Calls&amp;include_deleted=1
+
+</pre>
 
 <h2>Response Arguments</h2>
 <table class="table table-hover">
@@ -101,7 +107,7 @@ http://{site_url}/rest/vXX/Users/recentChanges
             <li>A list of records with recent changes.  Each list item contains the user's id and the user's username.
                 Each list item also contains a list of recently changed modules that includes a count of the number
                 of records assigned to that user that were changed in each module.</li>
-            </ul>
+        </ul>
         </td>
     </tr>
     </tbody>
@@ -110,7 +116,7 @@ http://{site_url}/rest/vXX/Users/recentChanges
 <h3>Response</h3>
 <pre class="pre-scrollable">
 {
-    "currentTime": "2018-03-01 19:44:18 UTC",
+    "currentTime": "2018-03-01T19:44:18+00:00",
     "records": [
         {
             "id": "seed_jim_id",

--- a/packages/RecentChangesAPI/src/custom/modules/Users/clients/base/api/help/CustomRecentChangesApi.html
+++ b/packages/RecentChangesAPI/src/custom/modules/Users/clients/base/api/help/CustomRecentChangesApi.html
@@ -1,0 +1,104 @@
+<!--
+/*
+    Copyright 2018 SugarCRM Inc.  Licensed by SugarCRM under the Apache 2.0 license.
+ */
+-->
+<div class="longHelpTitle">Identify Users who have had recent changes to their assigned records.</div>
+<div class="summary">
+    <h2>Summary:</h2>
+    This endpoint identifies Users who have had recent changes to their <strong>assigned</strong> records. Returns an array of User IDs based upon the filter criteria.
+</div>
+<h2>Request Arguments</h2>
+<table class="table table-hover">
+    <thead>
+    <tr>
+        <th>Name</th>
+        <th>Type</th>
+        <th>Description</th>
+        <th>Required</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>
+            since
+        </td>
+        <td>
+            Timestamp (String)
+        </td>
+        <td>
+            Selects users with records modified since this time.
+        </td>
+        <td>
+            True
+        </td>
+    </tr>
+    <tr>
+        <td>
+            module
+        </td>
+        <td>
+            String
+        </td>
+        <td>
+            A comma separated list of modules that will be checked. Modules must be assignable and therefore contain the <code>assigned_to_user field</code>.
+        </td>
+        <td>
+            True
+        </td>
+    </tr>
+    <tr>
+        <td>
+            include_deleted
+        </td>
+        <td>
+            Boolean
+        </td>
+        <td>
+            Determines if recently deleted records should be included as part of recent changes.
+        </td>
+        <td>
+            True
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+<h3>Request</h3>
+<pre class="pre-scrollable">
+http://{site_url}/rest/Users/recentChanges?since=2018-02-14T12:00:00Z&modules=Meetings,Calls&include_deleted=1
+</pre>
+<strong>Note:</strong> GET endpoint parameters are passed in the form of a query string.
+
+
+<h2>Response Arguments</h2>
+<table class="table table-hover">
+    <thead>
+    <tr>
+        <th>Name</th>
+        <th>Type</th>
+        <th>Description</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>
+            &lt;User IDs&gt;
+        </td>
+        <td>
+            Array&ltString&gt;
+        </td>
+        <td>
+            An array of User ID strings.
+        </td>
+    </tr>
+    </tbody>
+</table>
+
+<h3>Response</h3>
+<pre class="pre-scrollable">
+[
+    "1",
+    "c8bbe266-11ff-11e8-a823-080027e5359b"
+]
+</pre>

--- a/packages/RecentChangesAPI/src/custom/modules/Users/clients/base/api/help/CustomRecentChangesApi.html
+++ b/packages/RecentChangesAPI/src/custom/modules/Users/clients/base/api/help/CustomRecentChangesApi.html
@@ -6,7 +6,9 @@
 <div class="longHelpTitle">Identify Users who have had recent changes to their assigned records.</div>
 <div class="summary">
     <h2>Summary:</h2>
-    This endpoint identifies Users who have had recent changes to their <strong>assigned</strong> records. Returns an array of User IDs based upon the filter criteria.
+    This endpoint identifies Users who have had recent changes to their <strong>assigned</strong> records. Returns an
+    array that includes the time on the server when the request was executed and a list of user IDs and usernames for
+    users with changes.
 </div>
 <h2>Request Arguments</h2>
 <table class="table table-hover">
@@ -24,7 +26,7 @@
             since
         </td>
         <td>
-            Timestamp (String)
+            Timestamp (String) of the format <strong>Y-m-d G:i:s T</strong>
         </td>
         <td>
             Selects users with records modified since this time.
@@ -35,7 +37,7 @@
     </tr>
     <tr>
         <td>
-            module
+            modules
         </td>
         <td>
             String
@@ -52,7 +54,7 @@
             include_deleted
         </td>
         <td>
-            Boolean
+            Boolean (0 or 1)
         </td>
         <td>
             Determines if recently deleted records should be included as part of recent changes.
@@ -66,7 +68,7 @@
 
 <h3>Request</h3>
 <pre class="pre-scrollable">
-http://{site_url}/rest/Users/recentChanges?since=2018-02-14T12:00:00Z&modules=Meetings,Calls&include_deleted=1
+http://{site_url}/rest/vXX/Users/recentChanges?since=2018-02-15 00:00:00 UTC&modules=Meetings,Calls&include_deleted=1
 </pre>
 <strong>Note:</strong> GET endpoint parameters are passed in the form of a query string.
 
@@ -89,7 +91,11 @@ http://{site_url}/rest/Users/recentChanges?since=2018-02-14T12:00:00Z&modules=Me
             Array&ltString&gt;
         </td>
         <td>
-            An array of User ID strings.
+            A JSON array containing the following: <ul>
+            <li>The time the query was executed on the server</li>
+            <li>A list of users with recent changes.  Each list item contains the user's id and username. Note that
+            duplicate users will be included in the list if they have changes in more than one module.</li>
+            </ul>
         </td>
     </tr>
     </tbody>
@@ -97,8 +103,57 @@ http://{site_url}/rest/Users/recentChanges?since=2018-02-14T12:00:00Z&modules=Me
 
 <h3>Response</h3>
 <pre class="pre-scrollable">
-[
-    "1",
-    "c8bbe266-11ff-11e8-a823-080027e5359b"
-]
+{
+    "currentTime": "2018-02-21 19:19:07 UTC",
+    "usersWithRecentChanges": [
+        {
+            "assigned_user_id": "seed_chris_id",
+            "user_name": "chris"
+        },
+        {
+            "assigned_user_id": "seed_jim_id",
+            "user_name": "jim"
+        },
+        {
+            "assigned_user_id": "seed_max_id",
+            "user_name": "max"
+        },
+        {
+            "assigned_user_id": "seed_sally_id",
+            "user_name": "sally"
+        },
+        {
+            "assigned_user_id": "seed_sarah_id",
+            "user_name": "sarah"
+        },
+        {
+            "assigned_user_id": "seed_will_id",
+            "user_name": "will"
+        },
+        {
+            "assigned_user_id": "seed_chris_id",
+            "user_name": "chris"
+        },
+        {
+            "assigned_user_id": "seed_jim_id",
+            "user_name": "jim"
+        },
+        {
+            "assigned_user_id": "seed_max_id",
+            "user_name": "max"
+        },
+        {
+            "assigned_user_id": "seed_sally_id",
+            "user_name": "sally"
+        },
+        {
+            "assigned_user_id": "seed_sarah_id",
+            "user_name": "sarah"
+        },
+        {
+            "assigned_user_id": "seed_will_id",
+            "user_name": "will"
+        }
+    ]
+}
 </pre>

--- a/packages/RecentChangesAPI/src/custom/modules/Users/clients/base/api/help/CustomRecentChangesApi.html
+++ b/packages/RecentChangesAPI/src/custom/modules/Users/clients/base/api/help/CustomRecentChangesApi.html
@@ -51,13 +51,13 @@
     </tr>
     <tr>
         <td>
-            include_deleted
+            add_deleted
         </td>
         <td>
             Boolean (0 or 1)
         </td>
         <td>
-            Determines if recently deleted records should be included as part of recent changes.
+            Whether or not "'deleted' = 0" should be added to Where clause of generated SQL query.
         </td>
         <td>
             True
@@ -68,7 +68,7 @@
 
 <h3>Request</h3>
 <pre class="pre-scrollable">
-http://{site_url}/rest/vXX/Users/recentChanges?since=2018-02-15 00:00:00 UTC&modules=Meetings,Calls&include_deleted=1
+http://{site_url}/rest/vXX/Users/recentChanges?since=2018-02-27 15:09:09 UTC&modules=Meetings,Contacts&add_deleted=1
 </pre>
 <strong>Note:</strong> GET endpoint parameters are passed in the form of a query string.
 
@@ -93,8 +93,8 @@ http://{site_url}/rest/vXX/Users/recentChanges?since=2018-02-15 00:00:00 UTC&mod
         <td>
             A JSON array containing the following: <ul>
             <li>The time the query was executed on the server</li>
-            <li>A list of users with recent changes.  Each list item contains the user's id and username. Note that
-            duplicate users will be included in the list if they have changes in more than one module.</li>
+            <li>A list of records with recent changes.  Each list item contains the user's id, the user's username, and the
+                module where the record was changed.</li>
             </ul>
         </td>
     </tr>
@@ -104,55 +104,27 @@ http://{site_url}/rest/vXX/Users/recentChanges?since=2018-02-15 00:00:00 UTC&mod
 <h3>Response</h3>
 <pre class="pre-scrollable">
 {
-    "currentTime": "2018-02-21 19:19:07 UTC",
-    "usersWithRecentChanges": [
+    "currentTime": "2018-02-26 19:28:39 UTC",
+    "records": [
         {
-            "assigned_user_id": "seed_chris_id",
-            "user_name": "chris"
+            "id": "seed_chris_id",
+            "name": "chris",
+            "_module": "Meetings"
         },
         {
-            "assigned_user_id": "seed_jim_id",
-            "user_name": "jim"
+            "id": "seed_jim_id",
+            "name": "jim",
+            "_module": "Meetings"
         },
         {
-            "assigned_user_id": "seed_max_id",
-            "user_name": "max"
+            "id": "seed_jim_id",
+            "name": "jim",
+            "_module": "Contacts"
         },
         {
-            "assigned_user_id": "seed_sally_id",
-            "user_name": "sally"
-        },
-        {
-            "assigned_user_id": "seed_sarah_id",
-            "user_name": "sarah"
-        },
-        {
-            "assigned_user_id": "seed_will_id",
-            "user_name": "will"
-        },
-        {
-            "assigned_user_id": "seed_chris_id",
-            "user_name": "chris"
-        },
-        {
-            "assigned_user_id": "seed_jim_id",
-            "user_name": "jim"
-        },
-        {
-            "assigned_user_id": "seed_max_id",
-            "user_name": "max"
-        },
-        {
-            "assigned_user_id": "seed_sally_id",
-            "user_name": "sally"
-        },
-        {
-            "assigned_user_id": "seed_sarah_id",
-            "user_name": "sarah"
-        },
-        {
-            "assigned_user_id": "seed_will_id",
-            "user_name": "will"
+            "id": "seed_max_id",
+            "name": "max",
+            "_module": "Contacts"
         }
     ]
 }

--- a/packages/RecentChangesAPI/src/custom/modules/Users/clients/base/api/help/CustomRecentChangesApi.html
+++ b/packages/RecentChangesAPI/src/custom/modules/Users/clients/base/api/help/CustomRecentChangesApi.html
@@ -7,8 +7,8 @@
 <div class="summary">
     <h2>Summary:</h2>
     This endpoint identifies Users who have had recent changes to their <strong>assigned</strong> records. Returns an
-    array that includes the time on the server when the request was executed and a list of user IDs and usernames for
-    users with changes.
+    array that includes the time on the server when the request was executed and a list of user IDs, usernames, and
+    changed modules for users with changes.
 </div>
 <h2>Request Arguments</h2>
 <table class="table table-hover">
@@ -26,7 +26,8 @@
             since
         </td>
         <td>
-            Timestamp (String) of the format <strong>Y-m-d G:i:s T</strong>
+            Timestamp (String) of the format <strong>Y-m-d G:i:s T</strong>. For example, 2018-02-27%2015%3A09%3A09%20UTC
+            (url encoded) or 2018-02-27 15:09:09 UTC (decoded).
         </td>
         <td>
             Selects users with records modified since this time.
@@ -68,7 +69,7 @@
 
 <h3>Request</h3>
 <pre class="pre-scrollable">
-http://{site_url}/rest/vXX/Users/recentChanges?since=2018-02-27 15:09:09 UTC&modules=Meetings,Contacts&add_deleted=1
+http://{site_url}/rest/vXX/Users/recentChanges?since=2018-02-27%2015%3A09%3A09%20UTC&modules=Meetings,Contacts&add_deleted=1
 </pre>
 <strong>Note:</strong> GET endpoint parameters are passed in the form of a query string.
 
@@ -93,8 +94,8 @@ http://{site_url}/rest/vXX/Users/recentChanges?since=2018-02-27 15:09:09 UTC&mod
         <td>
             A JSON array containing the following: <ul>
             <li>The time the query was executed on the server</li>
-            <li>A list of records with recent changes.  Each list item contains the user's id, the user's username, and the
-                module where the record was changed.</li>
+            <li>A list of records with recent changes.  Each list item contains the user's id, the user's username, and
+                a list of modules where records were changed.</li>
             </ul>
         </td>
     </tr>
@@ -104,27 +105,22 @@ http://{site_url}/rest/vXX/Users/recentChanges?since=2018-02-27 15:09:09 UTC&mod
 <h3>Response</h3>
 <pre class="pre-scrollable">
 {
-    "currentTime": "2018-02-26 19:28:39 UTC",
+    "currentTime": "2018-02-28 18:41:42 UTC",
     "records": [
         {
-            "id": "seed_chris_id",
-            "name": "chris",
-            "_module": "Meetings"
-        },
-        {
             "id": "seed_jim_id",
             "name": "jim",
-            "_module": "Meetings"
+            "_recentlyChanged": [
+                "Meetings",
+                "Contacts"
+            ]
         },
         {
-            "id": "seed_jim_id",
-            "name": "jim",
-            "_module": "Contacts"
-        },
-        {
-            "id": "seed_max_id",
-            "name": "max",
-            "_module": "Contacts"
+            "id": "seed_sally_id",
+            "name": "sally",
+            "_recentlyChanged": [
+                "Contacts"
+            ]
         }
     ]
 }


### PR DESCRIPTION
@mmarum-sugarcrm Initial implementation is ready to go!  I have three questions for you that I left as TODOs in the code.  Two are just implementation questions.

The third question hits on a requirements question.  Let's say you're getting the changes for two modules:  Meetings and Calls.  The current response does not indicate which module the change is in...it's just a list of user IDs and associated usernames.  If a user has record changes in both Meetings and Calls, the user will be listed twice.  Here is a sample response.
```
{
    "currentTime": "2018-02-21 20:26:53 UTC",
    "usersWithRecentChanges": [
        {
            "assigned_user_id": "seed_jim_id",
            "user_name": "jim"
        },
        {
            "assigned_user_id": "seed_sally_id",
            "user_name": "sally"
        },
       {
            "assigned_user_id": "seed_jim_id",
            "user_name": "jim"
        }
    ]
}
```

If a user is listed only once, you won't know which module to check.  I'm not sure exactly how these results will be used.  I'm wondering if it might be more helpful to indicate the module in the results with something like the following:
```
{
    "currentTime": "2018-02-21 20:26:53 UTC",
    "modules": [
        {
            "Meetings": [
                {
                "assigned_user_id": "seed_jim_id",
                "user_name": "jim"
                }
            ],
            "Calls": [
                {
                "assigned_user_id": "seed_sally_id",
                "user_name": "sally"
                }, 
                {
                "assigned_user_id": "seed_jim_id",
                "user_name": "jim"
                }
            ]
        }
    ]
}
```

I guess the questions are... Does it help to know which module has changed?  If not, do we need to prune duplicates out of the results?